### PR TITLE
Rework telemetry documentation

### DIFF
--- a/general/telemetry.md
+++ b/general/telemetry.md
@@ -20,9 +20,7 @@ The following actions are captured:
 
 All `metrics` events also include your OS version, Zed app version, and a timestamp.
 
-#### Auditing your Metric Events
-
-You can see the metrics data that Zed has reported by running the command `zed: open telemetry log` from the command palette, or clicking `Help > View Telemetry Log` in the application menu.
+You can audit the metrics data that Zed has reported by running the command `zed: open telemetry log` from the command palette, or clicking `Help > View Telemetry Log` in the application menu.
 
 ## Configuring Telemetry Settings
 

--- a/general/telemetry.md
+++ b/general/telemetry.md
@@ -28,7 +28,7 @@ You have full control over what data is sent out by Zed.  To enable or disable s
 
 ```json
 "telemetry": {
-    "diagnostics": true,
+    "diagnostics": false,
     "metrics": false
 },
 ```

--- a/general/telemetry.md
+++ b/general/telemetry.md
@@ -1,19 +1,40 @@
 # Telemetry in Zed
 
-Zed collects anonymous telemetry data to help the team understand how people are using the app. When we release the public beta, we'll provide the ability to opt out of telemetry, but during the alpha, it isn't configurable.
+Zed collects anonymous telemetry data to help the team understand how people are using the application and to see what sort of severe issues they are experiencing.
 
-The telemetry data is not shared with Zed's servers, but is sent directly to an analytics service called [Mixpanel](https://mixpanel.com), where it remains anonymous, and can't be related to specific Zed users. Events are reported over HTTPS, and requests are rate-limited to avoid using significant network bandwidth.
+## Types of Telemetry
 
-Currently, the events that are reported are:
+### Diagnostics
 
-* Opening the app
-* Signing in
-* Opening and saving files. File extensions (e.g. `.rs`, `.html`, `.txt`) are included in these events.
+Diagnostic events include debug information (stack traces) from crash reports.  Crash reports are sent to a cloud-monitoring service called [Datadog](https://www.datadoghq.com).  Within Datadog, we can visualize how frequently users are running into issues and assess the severity of the issue.  Having these crash reports sent automatically allows us to begin implementing fixes without the user needing to file a report in our issue tracker.  Being able to see various crashes plotted in Datadog also gives us an informal measurement of the stability of Zed.
 
-All events also include your OS version, Zed app version, and a timestamp.
+### Metrics
 
-## Auditing your Telemetry Events
+Zed also collects metric information based on user actions.  Metric events are reported over HTTPS, and requests are rate-limited to avoid using significant network bandwidth. The telemetry data is not shared with Zed's servers; it is sent directly to an analytics service called [Mixpanel](https://mixpanel.com), where it remains anonymous, and can't be related to specific Zed users.
 
-You can see the telemetry data that Zed has reported by running the command `zed: open telemetry log` from the command palette, or clicking `Help > View Telemetry Log` in the application menu.
+The following actions are captured:
+
+- Opening the app
+- Signing in
+- Opening and saving files. File extensions (e.g. `.rs`, `.html`, `.txt`) are included in these events; code is *never* included in these events.
+
+All `metrics` events also include your OS version, Zed app version, and a timestamp.
+
+#### Auditing your Metric Events
+
+You can see the metrics data that Zed has reported by running the command `zed: open telemetry log` from the command palette, or clicking `Help > View Telemetry Log` in the application menu.
+
+## Configuring Telemetry Settings
+
+You have full control over what data is sent out by Zed.  To enable or disable some or all telemetry types, open your `settings.json` file via `zed: open settings` from the command palette.  Insert and tweak the following:
+
+```json
+"telemetry": {
+    "diagnostics": true,
+    "metrics": false
+},
+```
+
+## Concerns and Questions
 
 If you have concerns about telemetry, please feel free to open issues in our [community repository](https://github.com/zed-industries/community/issues/new/choose).

--- a/general/telemetry.md
+++ b/general/telemetry.md
@@ -33,6 +33,8 @@ You have full control over what data is sent out by Zed.  To enable or disable s
 },
 ```
 
+The telemetry settings can also be configured via the `welcome` screen, which can be invoked via the `workspace: welcome` action in the command palette.
+
 ## Concerns and Questions
 
 If you have concerns about telemetry, please feel free to open issues in our [community repository](https://github.com/zed-industries/community/issues/new/choose).


### PR DESCRIPTION
Closes: https://github.com/zed-industries/docs/issues/13

This PR reworks the telemetry documentation a bit to mention that telemetry can be disabled and to also state that we collect crash reports as well.  The settings for telemetry allow a user to configure both of these types of events, so I figured the documentation should be restructured to cover both.

```json
"telemetry": {
    // Send debug info like crash reports.
    "diagnostics": true,
    // Send anonymized usage data like what languages you're using Zed with.
    "metrics": true
},
```

Tagging in a few people on this one since telemetry is a hairy subject:

@ForLoveOfCats 
@mikayla-maki 
@nathansobo 