### PR TITLE
Update JS docs to new `languages` key in settings

### DIFF
--- a/languages/javascript.md
+++ b/languages/javascript.md
@@ -12,7 +12,7 @@ For example, if you have Prettier installed and on your `PATH`, you can use it f
 
 ```json
 {
-  "language_overrides": {
+  "languages": {
     "JavaScript": {
       "format_on_save": {
         "external": {


### PR DESCRIPTION
This confused me for a minute, trying to turn off JS format on save