### PR TITLE
Fix: Broken supported languages link

### DIFF
--- a/configuration/configuring-zed.md
+++ b/configuration/configuring-zed.md
@@ -177,7 +177,7 @@ To override settings for a language, add an entry for that languages name to the
 }
 ```
 
-For a complete list of languages you can override settings for see [Supported Languages](/docs/languages/supported-languages).
+For a complete list of languages you can override settings for see [Supported Languages](/languages/support-languages.md).
 
 ## Terminal
 


### PR DESCRIPTION
The current link to `Supported Languages` takes me to [Page Not Found](https://github.com/zed-industries/docs/blob/main/docs/languages/supported-languages/README.md)