### PR TITLE
Add troubleshooting for Python

### DIFF
--- a/languages/python.md
+++ b/languages/python.md
@@ -55,3 +55,15 @@ A common tool for formatting python code is [Black](https://black.readthedocs.io
   }
 }
 ```
+
+#### Troubleshooting
+
+The Pyright language server is built in TypeScript and requires Node.js and npm to run. Therefore, ensure you have Node.js and npm globally accessible in case IntelliSense is missing your Python files or Zed logs report as the following.
+```
+Language server error: Python
+
+failed to run npm info
+
+Caused by:
+    No such file or directory (os error 2)
+```


### PR DESCRIPTION
I noticed that the Node.js requirement for Python is a recurring issue in Discord and https://github.com/zed-industries/community. So, I propose a troubleshooting section in Python's docs.