### PR TITLE
fix c and c++ mixup

### DIFF
--- a/languages/c.md
+++ b/languages/c.md
@@ -1,4 +1,4 @@
-# C++
+# C
 
-- Tree Sitter: [tree-sitter-cpp](https://github.com/tree-sitter/tree-sitter-cpp)
+- Tree Sitter: [tree-sitter-c](https://github.com/tree-sitter/tree-sitter-c)
 - Language Server: [clangd](https://github.com/clangd/clangd)

--- a/languages/cpp.md
+++ b/languages/cpp.md
@@ -1,4 +1,4 @@
-# C
+# C++
 
-- Tree Sitter: [tree-sitter-c](https://github.com/tree-sitter/tree-sitter-c)
+- Tree Sitter: [tree-sitter-cpp](https://github.com/tree-sitter/tree-sitter-cpp)
 - Language Server: [clangd](https://github.com/clangd/clangd)


### PR DESCRIPTION
`languages/cpp.md` contained a link to tree-sitter grammar for C, and `languages/c.md` contained a link to tree-sitter grammar for C++. 😅

<img width="480" alt="image" src="https://user-images.githubusercontent.com/65303441/234719265-e5361914-d712-47c3-8e08-0969f6ef8494.png">

<img width="480" alt="image" src="https://user-images.githubusercontent.com/65303441/234719349-eae9602e-b6af-493b-ae35-c512b19b7a19.png">
