### PR TITLE
Fix backtick issue for new terminal keybinding

### DIFF
--- a/configuration/key-bindings.md
+++ b/configuration/key-bindings.md
@@ -68,7 +68,7 @@ There are some key bindings that can't be overridden; we are working on an issue
 | Increase buffer font size | Zed          | `Command + =`                                  |
 | Minimize                  | Zed          | `Command + M`                                  |
 | New file                  | Workspace    | `Command + N`                                  |
-| New terminal              | Workspace    | `Control + \` `                                |
+| New terminal              | Workspace    | ``Control + \``                                |
 | New window                | Workspace    | `Command + Shift + N`                          |
 | Open                      | Workspace    | `Command + O`                                  |
 | Open recent               | Projects     | `Alt + Command + O`                            |

--- a/configuration/key-bindings.md
+++ b/configuration/key-bindings.md
@@ -68,7 +68,7 @@ There are some key bindings that can't be overridden; we are working on an issue
 | Increase buffer font size | Zed          | `Command + =`                                  |
 | Minimize                  | Zed          | `Command + M`                                  |
 | New file                  | Workspace    | `Command + N`                                  |
-| New terminal              | Workspace    | ``Control + \``                                |
+| New terminal              | Workspace    | ```Control + \``                                |
 | New window                | Workspace    | `Command + Shift + N`                          |
 | Open                      | Workspace    | `Command + O`                                  |
 | Open recent               | Projects     | `Alt + Command + O`                            |

--- a/configuration/key-bindings.md
+++ b/configuration/key-bindings.md
@@ -68,7 +68,7 @@ There are some key bindings that can't be overridden; we are working on an issue
 | Increase buffer font size | Zed          | `Command + =`                                  |
 | Minimize                  | Zed          | `Command + M`                                  |
 | New file                  | Workspace    | `Command + N`                                  |
-| New terminal              | Workspace    | ```Control + ````                              |
+| New terminal              | Workspace    | `Control + &#96;`                              |
 | New window                | Workspace    | `Command + Shift + N`                          |
 | Open                      | Workspace    | `Command + O`                                  |
 | Open recent               | Projects     | `Alt + Command + O`                            |

--- a/configuration/key-bindings.md
+++ b/configuration/key-bindings.md
@@ -68,7 +68,7 @@ There are some key bindings that can't be overridden; we are working on an issue
 | Increase buffer font size | Zed          | `Command + =`                                  |
 | Minimize                  | Zed          | `Command + M`                                  |
 | New file                  | Workspace    | `Command + N`                                  |
-| New terminal              | Workspace    | ``Control + ```                                |
+| New terminal              | Workspace    | ``Control + ` ``                               |
 | New window                | Workspace    | `Command + Shift + N`                          |
 | Open                      | Workspace    | `Command + O`                                  |
 | Open recent               | Projects     | `Alt + Command + O`                            |

--- a/configuration/key-bindings.md
+++ b/configuration/key-bindings.md
@@ -68,7 +68,7 @@ There are some key bindings that can't be overridden; we are working on an issue
 | Increase buffer font size | Zed          | `Command + =`                                  |
 | Minimize                  | Zed          | `Command + M`                                  |
 | New file                  | Workspace    | `Command + N`                                  |
-| New terminal              | Workspace    | ``Control + ```                                |
+| New terminal              | Workspace    | ``Control + ``                                 |
 | New window                | Workspace    | `Command + Shift + N`                          |
 | Open                      | Workspace    | `Command + O`                                  |
 | Open recent               | Projects     | `Alt + Command + O`                            |

--- a/configuration/key-bindings.md
+++ b/configuration/key-bindings.md
@@ -68,7 +68,7 @@ There are some key bindings that can't be overridden; we are working on an issue
 | Increase buffer font size | Zed          | `Command + =`                                  |
 | Minimize                  | Zed          | `Command + M`                                  |
 | New file                  | Workspace    | `Command + N`                                  |
-| New terminal              | Workspace    | ``Control + \```                               |
+| New terminal              | Workspace    | ``Control + `\``                               |
 | New window                | Workspace    | `Command + Shift + N`                          |
 | Open                      | Workspace    | `Command + O`                                  |
 | Open recent               | Projects     | `Alt + Command + O`                            |

--- a/configuration/key-bindings.md
+++ b/configuration/key-bindings.md
@@ -68,7 +68,7 @@ There are some key bindings that can't be overridden; we are working on an issue
 | Increase buffer font size | Zed          | `Command + =`                                  |
 | Minimize                  | Zed          | `Command + M`                                  |
 | New file                  | Workspace    | `Command + N`                                  |
-| New terminal              | Workspace    | ``Control + ` `                                |
+| New terminal              | Workspace    | `Control + \``                                 |
 | New window                | Workspace    | `Command + Shift + N`                          |
 | Open                      | Workspace    | `Command + O`                                  |
 | Open recent               | Projects     | `Alt + Command + O`                            |

--- a/configuration/key-bindings.md
+++ b/configuration/key-bindings.md
@@ -68,7 +68,7 @@ There are some key bindings that can't be overridden; we are working on an issue
 | Increase buffer font size | Zed          | `Command + =`                                  |
 | Minimize                  | Zed          | `Command + M`                                  |
 | New file                  | Workspace    | `Command + N`                                  |
-| New terminal              | Workspace    | ``Control + `\`                                |
+| New terminal              | Workspace    | ``Control + ` `                                |
 | New window                | Workspace    | `Command + Shift + N`                          |
 | Open                      | Workspace    | `Command + O`                                  |
 | Open recent               | Projects     | `Alt + Command + O`                            |

--- a/configuration/key-bindings.md
+++ b/configuration/key-bindings.md
@@ -68,7 +68,7 @@ There are some key bindings that can't be overridden; we are working on an issue
 | Increase buffer font size | Zed          | `Command + =`                                  |
 | Minimize                  | Zed          | `Command + M`                                  |
 | New file                  | Workspace    | `Command + N`                                  |
-| New terminal              | Workspace    | ```Control + \``                                |
+| New terminal              | Workspace    | ```Control + ````                              |
 | New window                | Workspace    | `Command + Shift + N`                          |
 | Open                      | Workspace    | `Command + O`                                  |
 | Open recent               | Projects     | `Alt + Command + O`                            |

--- a/configuration/key-bindings.md
+++ b/configuration/key-bindings.md
@@ -68,7 +68,7 @@ There are some key bindings that can't be overridden; we are working on an issue
 | Increase buffer font size | Zed          | `Command + =`                                  |
 | Minimize                  | Zed          | `Command + M`                                  |
 | New file                  | Workspace    | `Command + N`                                  |
-| New terminal              | Workspace    | `Control + &#96;`                              |
+| New terminal              | Workspace    | `Control + ``                                  |
 | New window                | Workspace    | `Command + Shift + N`                          |
 | Open                      | Workspace    | `Command + O`                                  |
 | Open recent               | Projects     | `Alt + Command + O`                            |

--- a/configuration/key-bindings.md
+++ b/configuration/key-bindings.md
@@ -68,7 +68,7 @@ There are some key bindings that can't be overridden; we are working on an issue
 | Increase buffer font size | Zed          | `Command + =`                                  |
 | Minimize                  | Zed          | `Command + M`                                  |
 | New file                  | Workspace    | `Command + N`                                  |
-| New terminal              | Workspace    | ``Control + ``                                 |
+| New terminal              | Workspace    | ``Control + \```                               |
 | New window                | Workspace    | `Command + Shift + N`                          |
 | Open                      | Workspace    | `Command + O`                                  |
 | Open recent               | Projects     | `Alt + Command + O`                            |

--- a/configuration/key-bindings.md
+++ b/configuration/key-bindings.md
@@ -68,7 +68,7 @@ There are some key bindings that can't be overridden; we are working on an issue
 | Increase buffer font size | Zed          | `Command + =`                                  |
 | Minimize                  | Zed          | `Command + M`                                  |
 | New file                  | Workspace    | `Command + N`                                  |
-| New terminal              | Workspace    | `Control + \``                                 |
+| New terminal              | Workspace    | ``Control + ```                                |
 | New window                | Workspace    | `Command + Shift + N`                          |
 | Open                      | Workspace    | `Command + O`                                  |
 | Open recent               | Projects     | `Alt + Command + O`                            |

--- a/configuration/key-bindings.md
+++ b/configuration/key-bindings.md
@@ -68,7 +68,7 @@ There are some key bindings that can't be overridden; we are working on an issue
 | Increase buffer font size | Zed          | `Command + =`                                  |
 | Minimize                  | Zed          | `Command + M`                                  |
 | New file                  | Workspace    | `Command + N`                                  |
-| New terminal              | Workspace    | `Control + \``                                 |
+| New terminal              | Workspace    | `Control + \` `                                |
 | New window                | Workspace    | `Command + Shift + N`                          |
 | Open                      | Workspace    | `Command + O`                                  |
 | Open recent               | Projects     | `Alt + Command + O`                            |

--- a/configuration/key-bindings.md
+++ b/configuration/key-bindings.md
@@ -68,7 +68,7 @@ There are some key bindings that can't be overridden; we are working on an issue
 | Increase buffer font size | Zed          | `Command + =`                                  |
 | Minimize                  | Zed          | `Command + M`                                  |
 | New file                  | Workspace    | `Command + N`                                  |
-| New terminal              | Workspace    | `Control + ``                                  |
+| New terminal              | Workspace    | `Control + \``                                 |
 | New window                | Workspace    | `Command + Shift + N`                          |
 | Open                      | Workspace    | `Command + O`                                  |
 | Open recent               | Projects     | `Alt + Command + O`                            |

--- a/configuration/key-bindings.md
+++ b/configuration/key-bindings.md
@@ -68,7 +68,7 @@ There are some key bindings that can't be overridden; we are working on an issue
 | Increase buffer font size | Zed          | `Command + =`                                  |
 | Minimize                  | Zed          | `Command + M`                                  |
 | New file                  | Workspace    | `Command + N`                                  |
-| New terminal              | Workspace    | `Control + \``                                  |
+| New terminal              | Workspace    | `Control + \``                                 |
 | New window                | Workspace    | `Command + Shift + N`                          |
 | Open                      | Workspace    | `Command + O`                                  |
 | Open recent               | Projects     | `Alt + Command + O`                            |

--- a/configuration/key-bindings.md
+++ b/configuration/key-bindings.md
@@ -68,7 +68,7 @@ There are some key bindings that can't be overridden; we are working on an issue
 | Increase buffer font size | Zed          | `Command + =`                                  |
 | Minimize                  | Zed          | `Command + M`                                  |
 | New file                  | Workspace    | `Command + N`                                  |
-| New terminal              | Workspace    | ``Control + `\``                               |
+| New terminal              | Workspace    | ``Control + `\`                                |
 | New window                | Workspace    | `Command + Shift + N`                          |
 | Open                      | Workspace    | `Command + O`                                  |
 | Open recent               | Projects     | `Alt + Command + O`                            |

--- a/configuration/key-bindings.md
+++ b/configuration/key-bindings.md
@@ -68,7 +68,7 @@ There are some key bindings that can't be overridden; we are working on an issue
 | Increase buffer font size | Zed          | `Command + =`                                  |
 | Minimize                  | Zed          | `Command + M`                                  |
 | New file                  | Workspace    | `Command + N`                                  |
-| New terminal              | Workspace    | `Control + ``                                  |
+| New terminal              | Workspace    | `Control + \``                                  |
 | New window                | Workspace    | `Command + Shift + N`                          |
 | Open                      | Workspace    | `Command + O`                                  |
 | Open recent               | Projects     | `Alt + Command + O`                            |


### PR DESCRIPTION
The markdown code inline code block was broken due to the use of a double backtick. Adding a backwards slash in front of the backtick solves that.