### PR TITLE
Use correct context in test key binding

### DIFF
--- a/script/key-bindings/test_functions.py
+++ b/script/key-bindings/test_functions.py
@@ -92,13 +92,12 @@ def _():
 def _():
     keymap_data = [
         {
-            "context": "Editor",
             "bindings": {"ctrl-`": "workspace::NewTerminal"},
         }
     ]
 
     markdown_data = {
-        "editor": {
+        "global": {
             "commands": ["New terminal"],
             "targets": ["Workspace"],
             "shortcuts": ["``Control + ` ``"],


### PR DESCRIPTION
This isn't something that is actually tested against, but it should be accurate as to how our key bindings are scoped.