### PR TITLE
Update javascript.md - Missing "to" in sentence

### DIFF
--- a/languages/javascript.md
+++ b/languages/javascript.md
@@ -7,7 +7,7 @@
 
 Formatting on save is enabled by default for JavaScript, using TypeScript's built-in code formatting. But many JavaScript projects use other command-line code-formatting tools, such as [Prettier](https://prettier.io/). You can use one of these tools by specifying an _external_ code formatter for JavaScript in your settings. See the [configuration](../configuration/configuring-zed.md) documentation for more information.
 
-For example, if you have Prettier installed and on your `PATH`, you can use it format JavaScript files by adding the following to your `settings.json`:
+For example, if you have Prettier installed and on your `PATH`, you can use it to format JavaScript files by adding the following to your `settings.json`:
 
 ```json
 {


### PR DESCRIPTION
I saw that there was a missing "to" in the sentence below:

`For example, if you have Prettier installed and on your PATH, you can use it format JavaScript files by adding the following to your settings.json:`

Update to the following 

`For example, if you have Prettier installed and on your PATH, you can use it to format JavaScript files by adding the following to your settings.json:`