### PR TITLE
Add inlay hint settings example

### DIFF
--- a/configuration/configuring-zed.md
+++ b/configuration/configuring-zed.md
@@ -349,6 +349,47 @@ To override settings for a language, add an entry for that language server's nam
 
 `boolean` values
 
+## Inlay hints
+
+- Description: Configuration for displaying extra text with hints in the editor.
+- Setting: `inlay_hints`
+- Default:
+
+```json
+"inlay_hints": {
+  "enabled": false,
+  "show_type_hints": true,
+  "show_parameter_hints": true,
+  "show_other_hints": true
+}
+```
+
+**Options**
+
+Inlay hints can be disabled or enabled per language and may toggle certain hint types separately.
+In addition to that, corresponding language server might have more hint types than LSP defines, and more hint-related settings.
+To configure them, refer to server's documentation and use `lsp` section for the server settings.
+Example for rust-analyzer language server:
+
+```json
+"lsp": {
+  "rust-analyzer": {
+    "initialization_options": {
+        "inlayHints": {
+            "maxLength": null,
+            "lifetimeElisionHints": {
+                "useParameterNames": true,
+                "enable": "skip_trivial"
+            },
+            "closureReturnTypeHints": {
+                "enable": "always"
+            }
+        }
+    }
+  }
+}
+```
+
 ## Journal
 
 - Description: Configuration for the journal.

--- a/configuration/configuring-zed.md
+++ b/configuration/configuring-zed.md
@@ -366,10 +366,11 @@ To override settings for a language, add an entry for that language server's nam
 
 **Options**
 
-Inlay hints can be disabled or enabled per language and may toggle certain hint types separately.
-In addition to that, corresponding language server might have more hint types than LSP defines, and more hint-related settings.
-To configure them, refer to server's documentation and use `lsp` section for the server settings.
-Example for rust-analyzer language server:
+Inlay hints querying consists of two parts: editor (client) and LSP server.
+With the inlay settings above are changed to enable the hints, editor will start to query certain types of hints and react on LSP hint refresh request from the server.
+At this point, the server may or may not return hints depending on its implementation, further configuration might be needed, refer to the corresponding LSP server documentation.
+
+Use `lsp` section for the server configuration, below is an example of Rust and TypeScript servers:
 
 ```json
 "lsp": {
@@ -386,6 +387,20 @@ Example for rust-analyzer language server:
             }
         }
     }
+  },
+  "typescript-language-server": {
+      "initialization_options": {
+          "preferences": {
+              "includeInlayParameterNameHints": "all",
+              "includeInlayParameterNameHintsWhenArgumentMatchesName": true,
+              "includeInlayFunctionParameterTypeHints": true,
+              "includeInlayVariableTypeHints": true,
+              "includeInlayVariableTypeHintsWhenTypeMatchesName": false,
+              "includeInlayPropertyDeclarationTypeHints": true,
+              "includeInlayFunctionLikeReturnTypeHints": true,
+              "includeInlayEnumMemberValueHints": true
+          }
+      }
   }
 }
 ```


### PR DESCRIPTION
Closes https://linear.app/zed-industries/issue/Z-2344/document-how-to-configure-inlays-in-rust-and-other-popular-languages

The issue mentions "other popular languages", should we have more LSP config examples for these? Or would only Rust LSP  be enough, given how minimalistic other sections are?