### PR TITLE
Rename arguments key to args

### DIFF
--- a/configuration/configuring-zed.md
+++ b/configuration/configuring-zed.md
@@ -819,7 +819,7 @@ See Buffer Font Features
 "shell": {
   "with_arguments": {
     "program": "/bin/bash",
-    "arguments": ["--login"]
+    "args": ["--login"]
   }
 }
 ```


### PR DESCRIPTION
Rename shell / with_arguments / arguments key to args.