### PR TITLE
Include example setup svelte

### DIFF
--- a/configuration/configuring-zed.md
+++ b/configuration/configuring-zed.md
@@ -434,6 +434,30 @@ Use `lsp` section for the server configuration, below are some examples for well
 }
 ```
 
+### Svelte
+
+```json
+{
+  "lsp": {
+    "typescript-language-server": {
+      "initialization_options": {
+        "preferences": {
+          "includeInlayParameterNameHints": "all",
+          "includeInlayParameterNameHintsWhenArgumentMatchesName": true,
+          "includeInlayFunctionParameterTypeHints": true,
+          "includeInlayVariableTypeHints": true,
+          "includeInlayVariableTypeHintsWhenTypeMatchesName": false,
+          "includeInlayPropertyDeclarationTypeHints": true,
+          "includeInlayFunctionLikeReturnTypeHints": true,
+          "includeInlayEnumMemberValueHints": true,
+          "includeInlayEnumMemberDeclarationTypes": true
+        }
+      }
+    }
+  }
+}
+```
+
 ## Journal
 
 - Description: Configuration for the journal.


### PR DESCRIPTION
This update aims to enhance the documentation for Svelte, specifically focusing on configuring the TypeScript Language Server within the Zed editor. I hope that by providing detailed instructions and settings preferences, community members will find it easier to work with Svelte projects in Zed