### PR TITLE
fix: typo in vim docs

### DIFF
--- a/general/vim.md
+++ b/general/vim.md
@@ -145,11 +145,11 @@ There are a few Zed settings that you may also enjoy if you use vim mode:
 ```
 {
   // disable cursor blink
-  "cursor_blink": false
+  "cursor_blink": false,
   // use relative line numbers
   "relative_line_numbers": true,
   // hide the scroll bar
-  "scrollbar": {"show": "never"},
+  "scrollbar": {"show": "never"}
 }
 ```
 


### PR DESCRIPTION
PR: make copy example mindlessly copy paste-able, aka, valid JSON.

Trying out zed again after a bit and copy pasta from docs didn't work. So here's my [boy scout commit](https://schneide.blog/2022/01/13/the-boy-scout-rule-and-git-in-practice/).

aside: the behaviour of CMD+N and Right Click in Files Explorer and New File is different, is there a setting to fix that? This is an issue cause new file in can create entire path eg, `.zed/settings.json`. But saving an empty file using MacOS finder can't do so.